### PR TITLE
fix: restore MCP tool proactiveness with positive, action-oriented descriptions

### DIFF
--- a/pkg/claude/knowledge/INSTRUCTIONS.md
+++ b/pkg/claude/knowledge/INSTRUCTIONS.md
@@ -1,28 +1,35 @@
 # 🧠 Knowledge Remembering Protocol
 
-You have access to the remember tool. You MUST use it PROACTIVELY to capture ALL discoveries about this project.
+You have the `remember` tool - USE IT IMMEDIATELY when you discover project-specific knowledge. This creates persistent memory that survives context resets.
 
-Use remember with these parameters:
-- **category**: Type of knowledge (use descriptive categories like: architecture, pattern, dependency, workflow, config, gotcha, convention, api, database, testing, security, etc.)
-- **topic**: Brief title of what you learned
-- **details**: Specific information discovered
-- **files**: Related file paths (optional)
+## 🎯 Remember Parameters
+- **category**: Knowledge type (architecture, api, database, pattern, dependency, workflow, config, gotcha, convention, testing, security, etc.)
+- **topic**: Clear title for your discovery
+- **details**: Complete specifics with context
+- **files**: Related file paths (recommended)
 
-✅ CAPTURE when discovering:
-- How things actually work in this project
-- Architecture, patterns, or conventions
-- Configuration details or requirements
-- Dependencies, integrations, or APIs
-- Non-obvious behaviors or gotchas
-- Workflows, processes, or project-specific details
+## ⚡ IMMEDIATE CAPTURE TRIGGERS
+**Use remember the moment you:**
+- Discover how something works in this project
+- Learn architecture, patterns, or conventions
+- Find configuration details or requirements
+- Understand dependencies, integrations, or APIs
+- Encounter non-obvious behaviors or gotchas
+- Figure out workflows or project-specific processes
 
-❌ DON'T capture:
-- Issues you're actively fixing in this session
-- Requirements for the current in-flight issue
-- Temporary debugging output
-- Generic programming knowledge (not project-specific)
+## 🔑 Key Phrases = Remember Now
+When you think/say: "I learned that", "turns out", "actually it's", "I discovered", "for future reference", "good to know", "interesting that" → REMEMBER IT
 
-When in doubt, capture it - better to remember too much than miss important discoveries.
+## 📋 Examples of What to Remember
+✅ Database schema conventions discovered
+✅ API authentication flows figured out
+✅ Build system quirks encountered
+✅ Project-specific patterns identified
+✅ Configuration requirements found
+
+❌ Skip: Current bug fixes, temporary debug output, generic programming concepts
+
+**ACTION: Capture project discoveries immediately - every insight feeds the Wellspring of Knowledge.**
 
 ## ⚠️ Remember Knowledge First
 

--- a/pkg/claude/servers/mim.cjs
+++ b/pkg/claude/servers/mim.cjs
@@ -71,23 +71,24 @@ rl.on('line', (line) => {
             respond(request.id, {
                 tools: [{
                     name: 'remember',
-                    description: `Capture learned information about the project for automatic documentation. Use PROACTIVELY when discovering architecture, patterns, dependencies, workflows, configurations, or surprising behaviors.
+                    description: `Capture project discoveries and learnings for persistent documentation. Automatically preserves knowledge about architecture, patterns, workflows, dependencies, configurations, and unique behaviors.
 
-⚠️ MANDATORY TRIGGERS - Use this tool IMMEDIATELY when:
-• You say/think: "for future reference", "I learned that", "turns out", "actually it's", "I discovered", "good to know", "I see that", "interesting that"
-• You made a mistake and learned the correct approach
-• You discovered how something actually works (vs what you assumed)
-• You found a project-specific convention, pattern, or requirement
-• You figured out why something wasn't working
-• You realize your initial assumption was wrong
+🎯 USE THIS TOOL when you:
+• Discover how something works in this project
+• Learn project-specific patterns or conventions
+• Find configuration details or requirements
+• Understand architecture or system design
+• Encounter non-obvious behaviors or gotchas
+• Figure out dependencies or integrations
+• Realize your assumptions were incorrect
 
-DON'T REMEMBER:
-• Issues you're actively fixing right now
-• Requirements for the current in-flight issue
-• Temporary debugging output
-• Generic programming knowledge (not project-specific)
+💡 KEY TRIGGERS - phrases that signal discovery:
+"I learned that", "turns out", "actually it's", "I discovered", "for future reference", "good to know", "interesting that"
 
-When in doubt, remember it - better to capture too much than miss important discoveries.`,
+⚡ ALWAYS CAPTURE project-specific knowledge immediately - this creates the persistent memory that survives context resets.
+
+✓ Examples: Database schema conventions, API authentication flows, build system quirks
+✗ Skip: Current bug fixes, temporary debug output, generic programming concepts`,
                     inputSchema: {
                         type: 'object',
                         properties: {


### PR DESCRIPTION
- Replace negative 'DON'T REMEMBER' focus with positive 'USE THIS TOOL when'
- Add immediate action triggers and clear visual hierarchy
- Use active voice and benefit-first approach per MCP best practices
- Emphasize capturing discoveries immediately for persistent memory